### PR TITLE
added some settings to eliminate ssh auth error caused by an ansible bug.…

### DIFF
--- a/os-centos-7.4-x86_64.json
+++ b/os-centos-7.4-x86_64.json
@@ -47,7 +47,11 @@
     },
     {
       "type": "ansible",
-      "playbook_file": "./hardening.yml"
+      "playbook_file": "./hardening.yml",
+      "extra_arguments": [
+        "--ssh-extra-args",
+        "-o IdentitiesOnly=yes"
+      ]
     }
   ],
 


### PR DESCRIPTION
when you loaded too many keys with ssh-add it would try all the keys until it came to the generated packer one. But then the setting 'MaxAuthTries' in sshd_config of the ubuntu AMI kicked in (default 6).

This change would tell SSH to only use the private key specified to Ansible with --private-key and prevent people with too many SSH keys loaded in their agent from running into auth errors from trying too many keys. 

see https://github.com/hashicorp/packer/issues/5329 and 
https://github.com/hashicorp/packer/issues/5065