### PR TITLE
Bumping up jenkins-agent nodejs version to 12.x

### DIFF
--- a/jenkins-agent-centos-7.4-x86_64.json
+++ b/jenkins-agent-centos-7.4-x86_64.json
@@ -42,7 +42,7 @@
         "yum install -y cloud-init epel-release libselinux-python centos-release-scl",
         "yum install -y python3-pip",
         "pip3 install --upgrade docker-compose",
-        "curl --location https://rpm.nodesource.com/setup_8.x | sudo bash -",
+        "curl --location https://rpm.nodesource.com/setup_12.x | sudo bash -",
         "rpm --import https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY https://repo.ius.io/RPM-GPG-KEY-IUS-7",
         "yum install -y https://centos7.iuscommunity.org/ius-release.rpm",
         "yum install -y nodejs",


### PR DESCRIPTION
### JIRA link (if applicable) ###
[AB#732](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/732)

### Change description ###
Bumping up jenkins agent nodejs version to 12.x (latest 12.13.0)

**Does this PR introduce a breaking change?** (check one with "x")
```
[x ] Yes
[ ] No
```
