### PR TITLE
DTSPO-14034 - Build arm64 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
               vm_size=$(vm_size)
           command: build
           azureSubscription: dts-management-prod-intsvc
-          options: --only=azure-arm.no-publish
+          options: --only=azure-arm.pr-build-and-publish
 
       - task: AzureCLI@2.208.0
         displayName: Cleanup resources on fail
@@ -112,8 +112,19 @@ jobs:
             resource_group_name=$(echo $(prbuild.DeploymentName) | sed 's/pkrdp//')
             az group delete --name "pkr-Resource-Group-${resource_group_name}" --yes
 
+      - task: AzureCLI@2.208.0
+        displayName: Delete published PR build image version
+        condition: succeededOrFailed()
+        name: delete_pr_azure_image_version
+        inputs:
+          azureSubscription: dts-management-prod-intsvc
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            az sig image-version delete --gallery-image-version $(get_azure_image_version.azure_image_version) --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+
       - task: riezebosch.Packer.Packer.Packer@1
-        displayName: 'Build and publish'
+        displayName: 'Master Build'
         condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
         inputs:
           templatePath: $(templatePath)
@@ -125,7 +136,7 @@ jobs:
               vm_size=$(vm_size)
           command: build
           azureSubscription: dts-management-prod-intsvc
-          options: --only=azure-arm.build-and-publish
+          options: --only=azure-arm.master-build-and-publish
 
       - task: GitHubRelease@1
         displayName: Create GitHubRelease

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,6 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              architecture=$(architecture)
               azure_image_version=$(get_azure_image_version.azure_image_version)
               image_name=$(image_name)
               jenkins_ssh_key=$(JENKINS_SSH_KEY)
@@ -119,7 +118,6 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              architecture=$(architecture)
               azure_image_version=$(get_azure_image_version.azure_image_version)
               image_name=$(image_name)
               jenkins_ssh_key=$(JENKINS_SSH_KEY)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'PR Build'
         name: prbuild
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq($(image_name), "jenkins-ubuntu"))
         inputs:
           templatePath: $(templatePath)
           variables: |
@@ -114,7 +114,7 @@ jobs:
 
       - task: AzureCLI@2.208.0
         displayName: Delete published PR build image version
-        condition: succeededOrFailed()
+        condition: and(succeededOrFailed(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
         name: delete_pr_azure_image_version
         inputs:
           azureSubscription: dts-management-prod-intsvc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,13 +30,13 @@ jobs:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        Ubuntu-x64:
+        Ubuntu-amd64:
           architecture: "amd64"
           image_name: "jenkins-ubuntu"
           image_sku: 20_04-lts
           templatePath: jenkins-agent-ubuntu.pkr.hcl
           vm_size: "Standard_D4ds_v5"
-        Ubuntu-Arm64:
+        Ubuntu-arm64:
           architecture: "arm64"
           image_name: "jenkins-ubuntu-arm"
           image_sku: 20_04-lts-arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,13 +31,11 @@ jobs:
     strategy:
       matrix:
         Ubuntu-amd64:
-          architecture: "amd64"
           image_name: "jenkins-ubuntu"
           image_sku: 20_04-lts
           templatePath: jenkins-agent-ubuntu.pkr.hcl
           vm_size: "Standard_D4ds_v5"
         Ubuntu-arm64:
-          architecture: "arm64"
           image_name: "jenkins-ubuntu-arm"
           image_sku: 20_04-lts-arm64
           templatePath: jenkins-agent-ubuntu.pkr.hcl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,18 @@ jobs:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        Ubuntu:
-          os: Ubuntu
+        Ubuntu-x64:
+          architecture: "amd64"
+          image_name: "jenkins-ubuntu"
+          image_sku: 20_04-lts
           templatePath: jenkins-agent-ubuntu.pkr.hcl
+          vm_size: "Standard_D4ds_v5"
+        Ubuntu-Arm64:
+          architecture: "arm64"
+          image_name: "jenkins-ubuntu-arm"
+          image_sku: 20_04-lts-arm64
+          templatePath: jenkins-agent-ubuntu.pkr.hcl
+          vm_size: "Standard_D4pds_v5"
     timeoutInMinutes: "120"
     steps:
       - checkout: self
@@ -45,7 +54,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            AZURE_IMAGE_VERSION=$(az sig image-version list --gallery-image-definition jenkins-ubuntu --gallery-name hmcts --resource-group hmcts-image-gallery-rg --query '[].{name:name}' -o tsv | sort -V | tail -n1)
+            AZURE_IMAGE_VERSION=$(az sig image-version list --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg --query '[].{name:name}' -o tsv | sort -V | tail -n1)
             IFS=. read -r major minor patch <<<"$AZURE_IMAGE_VERSION"
             ((patch++))
             printf -v AZURE_IMAGE_VERSION '%d.%d.%d' "$major" "$minor" "$((patch))"
@@ -60,7 +69,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            groups=$(az group list --tag 'imagetype=jenkins-ubuntu' | jq -r '.[].name')
+            groups=$(az group list --tag 'imagetype=$(image_name)' | jq -r '.[].name')
             for group in ${groups[@]}; do
             echo "deleting resource group $group"
             az group delete --name $group --yes
@@ -85,8 +94,12 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              jenkins_ssh_key=$(JENKINS_SSH_KEY)
+              architecture=$(architecture)
               azure_image_version=$(get_azure_image_version.azure_image_version)
+              image_name=$(image_name)
+              jenkins_ssh_key=$(JENKINS_SSH_KEY)
+              image_sku=$(image_sku)
+              vm_size=$(vm_size)
           command: build
           azureSubscription: dts-management-prod-intsvc
           options: --only=azure-arm.no-publish
@@ -108,8 +121,12 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              jenkins_ssh_key=$(JENKINS_SSH_KEY)
+              architecture=$(architecture)
               azure_image_version=$(get_azure_image_version.azure_image_version)
+              image_name=$(image_name)
+              jenkins_ssh_key=$(JENKINS_SSH_KEY)
+              image_sku=$(image_sku)
+              vm_size=$(vm_size)
           command: build
           azureSubscription: dts-management-prod-intsvc
           options: --only=azure-arm.build-and-publish

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'PR Build'
         name: prbuild
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq($(image_name), "jenkins-ubuntu"))
+        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.image_name, 'jenkins-ubuntu'))
         inputs:
           templatePath: $(templatePath)
           variables: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'PR Build'
         name: prbuild
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.image_name, 'jenkins-ubuntu'))
+        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
         inputs:
           templatePath: $(templatePath)
           variables: |
@@ -140,7 +140,7 @@ jobs:
 
       - task: GitHubRelease@1
         displayName: Create GitHubRelease
-        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.image_name, 'jenkins-ubuntu'))
         inputs:
           gitHubConnection: 'GitHub Management - Full Repo Access'
           repositoryName: '$(Build.Repository.Name)'

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -89,11 +89,6 @@ variable "vm_size" {
   default = "Standard_D4ds_v5"
 }
 
-variable "architecture" {
-  type = string
-  default = "amd64"
-}
-
 source "azure-arm" "no-publish" {
   azure_tags = {
     imagetype = var.image_name
@@ -151,10 +146,7 @@ build {
   provisioner "shell" {
     execute_command = "echo '${var.ssh_password}' | {{ .Vars }} sudo -S -E bash '{{ .Path }}'"
     script          = "provision-jenkins-ubuntu-agent.sh"
-    environment_vars = [
-      "JENKINS_SSH_KEY=${var.jenkins_ssh_key}",
-      "ARCHITECTURE=${var.architecture}"
-    ]
+    environment_vars = ["JENKINS_SSH_KEY=${var.jenkins_ssh_key}"]
     max_retries = 5
   }
 

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -71,7 +71,7 @@ variable "image_publisher" {
 
 variable "image_sku" {
   type = string
-  default = "20_04-lts-arm64"
+  default = "20_04-lts"
 }
 
 variable "image_name" {
@@ -87,6 +87,11 @@ variable "os_type" {
 variable "vm_size" {
   type = string
   default = "Standard_D4pds_v5"
+}
+
+variable "architecture" {
+  type = string
+  default = "amd64"
 }
 
 source "azure-arm" "no-publish" {
@@ -146,7 +151,10 @@ build {
   provisioner "shell" {
     execute_command = "echo '${var.ssh_password}' | {{ .Vars }} sudo -S -E bash '{{ .Path }}'"
     script          = "provision-jenkins-ubuntu-agent.sh"
-    environment_vars = ["JENKINS_SSH_KEY=${var.jenkins_ssh_key}"]
+    environment_vars = [
+      "JENKINS_SSH_KEY=${var.jenkins_ssh_key}",
+      "ARCHITECTURE=${var.architecture}"
+    ]
     max_retries = 5
   }
 

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -76,7 +76,7 @@ variable "image_sku" {
 
 variable "image_name" {
   type = string
-  default = "jenkins-ubuntu-arm"
+  default = "jenkins-ubuntu"
 }
 
 variable "os_type" {
@@ -86,7 +86,7 @@ variable "os_type" {
 
 variable "vm_size" {
   type = string
-  default = "Standard_D4pds_v5"
+  default = "Standard_D4ds_v5"
 }
 
 variable "architecture" {

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -76,7 +76,7 @@ variable "image_sku" {
 
 variable "image_name" {
   type = string
-  default = "jenkins-ubuntu"
+  default = "jenkins-ubuntu-arm"
 }
 
 variable "os_type" {
@@ -86,7 +86,7 @@ variable "os_type" {
 
 variable "vm_size" {
   type = string
-  default = "Standard_D4ds_v5"
+  default = "Standard_D4pds_v5"
 }
 
 source "azure-arm" "no-publish" {

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -89,7 +89,7 @@ variable "vm_size" {
   default = "Standard_D4ds_v5"
 }
 
-source "azure-arm" "no-publish" {
+source "azure-arm" "pr-build-and-publish" {
   azure_tags = {
     imagetype = var.image_name
     timestamp = formatdate("YYYYMMDDhhmmss",timestamp())
@@ -106,9 +106,18 @@ source "azure-arm" "no-publish" {
   subscription_id                   = var.subscription_id
   tenant_id                         = var.tenant_id
   vm_size                           = var.vm_size
+
+  shared_image_gallery_destination {
+     subscription        = var.subscription_id
+     resource_group      = var.resource_group_name
+     gallery_name        = "hmcts"
+     image_name          = var.image_name
+     image_version       = var.azure_image_version
+     replication_regions = ["UK South"]
+   }
 }
 
-source "azure-arm" "build-and-publish" {
+source "azure-arm" "master-build-and-publish" {
   azure_tags = {
     imagetype = var.image_name
     timestamp = formatdate("YYYYMMDDhhmmss",timestamp())
@@ -139,7 +148,7 @@ source "azure-arm" "build-and-publish" {
 }
 
 build {
-  sources = ["source.azure-arm.no-publish","source.azure-arm.build-and-publish"]
+  sources = ["source.azure-arm.pr-build-and-publish","source.azure-arm.master-build-and-publish"]
 
   provisioner "shell" {
     execute_command = "echo '${var.ssh_password}' | {{ .Vars }} sudo -S -E bash '{{ .Path }}'"

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -134,7 +134,7 @@ source "azure-arm" "build-and-publish" {
      subscription        = var.subscription_id
      resource_group      = var.resource_group_name
      gallery_name        = "hmcts"
-     image_name          = "jenkins-ubuntu"
+     image_name          = var.image_name
      image_version       = var.azure_image_version
      replication_regions = ["UK South"]
    }

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -71,7 +71,7 @@ variable "image_publisher" {
 
 variable "image_sku" {
   type = string
-  default = "20_04-lts"
+  default = "20_04-lts-arm64"
 }
 
 variable "image_name" {

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -100,8 +100,6 @@ source "azure-arm" "no-publish" {
   image_offer                       = var.image_offer
   image_sku                         = var.image_sku
   location                          = var.azure_location
-  managed_image_name                = "${var.image_name}-${formatdate("YYYYMMDDhhmmss",timestamp())}"
-  managed_image_resource_group_name = var.resource_group_name
   os_type                           = var.os_type
   ssh_pty                           = "true"
   ssh_username                      = var.ssh_user

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -30,6 +30,8 @@ echo '-----BEGIN RSA PRIVATE KEY-----' | tee /opt/jenkinsssh_id_rsa
 echo $JENKINS_SSH_KEY | sed -e 's/[[:blank:]]\\+/\\n/g' | tee -a /opt/jenkinsssh_id_rsa
 echo '-----END RSA PRIVATE KEY-----' | tee -a /opt/jenkinsssh_id_rsa
 
+ARCHITECTURE=$(dpkg --print-architecture)
+
 remove_packages=( docker docker-engine docker.io runc )
 
 for i in "${remove_packages[@]}"

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -73,7 +73,7 @@ rm -rf /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 chmod a+r /etc/apt/keyrings/docker.gpg
 
-echo "deb [arch="$(dpkg --print-ARCHITECTURE)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -197,11 +197,13 @@ fi
 curl -fL -o tfcmt.tar.gz https://github.com/suzuki-shunsuke/tfcmt/releases/download/v${TFCMT_VERSION}/tfcmt_linux_${ARCHITECTURE}.tar.gz
 tar -C /usr/bin -xzf ./tfcmt.tar.gz tfcmt
 
-[ -e /opt/google/chrome/libosmesa.so ] && rm /opt/google/chrome/libosmesa.so
-LIBOSMESA=$(find /usr -name 'libOSMesa*' -type f)M
-ln -s $LIBOSMESA /opt/google/chrome/libosmesa.so
-echo 'user.max_user_namespaces=10000' > /etc/sysctl.d/90-userspace.conf
-# grubby --args=namespace.unpriv_enable=1 --update-kernel=$(grubby --default-kernel)
+if [ ${ARCHITECTURE} = "amd64" ]; then
+  [ -e /opt/google/chrome/libosmesa.so ] && rm /opt/google/chrome/libosmesa.so
+  LIBOSMESA=$(find /usr -name 'libOSMesa*' -type f)M
+  ln -s $LIBOSMESA /opt/google/chrome/libosmesa.so
+  echo 'user.max_user_namespaces=10000' > /etc/sysctl.d/90-userspace.conf
+  # grubby --args=namespace.unpriv_enable=1 --update-kernel=$(grubby --default-kernel)
+fi
 
 mkdir /etc/docker && chown -R root:root /etc/docker && chmod 0755 /etc/docker
 echo -e '{\n  \live-restore\: true,\n  \group\: \docker\\n}' > /etc/docker/daemon.conf && chown root:root /etc/docker/daemon.conf && chmod 0644 /etc/docker/daemon.conf

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -190,7 +190,7 @@ if [ ${ARCHITECTURE} = "amd64" ]; then
   apt install -y ./google-chrome-stable_current_${ARCHITECTURE}.deb
   rm -f google-chrome-stable_current_${ARCHITECTURE}.deb
 else
-  apt install -y chromium-browser
+  apt install -y chromium-browser chromium-chromedriver
 fi
 
 
@@ -198,7 +198,7 @@ curl -fL -o tfcmt.tar.gz https://github.com/suzuki-shunsuke/tfcmt/releases/downl
 tar -C /usr/bin -xzf ./tfcmt.tar.gz tfcmt
 
 [ -e /opt/google/chrome/libosmesa.so ] && rm /opt/google/chrome/libosmesa.so
-LIBOSMESA=$(find /usr -name 'libOSMesa*' -type f)
+LIBOSMESA=$(find /usr -name 'libOSMesa*' -type f)M
 ln -s $LIBOSMESA /opt/google/chrome/libosmesa.so
 echo 'user.max_user_namespaces=10000' > /etc/sysctl.d/90-userspace.conf
 # grubby --args=namespace.unpriv_enable=1 --update-kernel=$(grubby --default-kernel)

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -255,7 +255,13 @@ curl https://pyenv.run | bash
 ln -s /opt/.pyenv/bin/* /bin
 chown -R 1001:1001 /opt/.pyenv
 
-packages=( az azcopy docker docker-compose eslint gcc git google-chrome gulp java jq make node npm psql pyenv ruby rsync sonar-scanner terraform tfcmt tfenv virtualenv yarn wget zip )
+packages=( az azcopy docker docker-compose eslint gcc git gulp java jq make node npm psql pyenv ruby rsync sonar-scanner terraform tfcmt tfenv virtualenv yarn wget zip )
+
+if [ ${ARCHITECTURE} = "amd64" ]; then
+  packages+=('google-chrome')
+else
+  packages+=('chromium')
+fi
 
 for i in "${packages[@]}"
 

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -73,7 +73,7 @@ rm -rf /etc/apt/keyrings/docker.gpg
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 chmod a+r /etc/apt/keyrings/docker.gpg
 
-echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo "deb [arch="$(dpkg --print-ARCHITECTURE)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
@@ -104,7 +104,6 @@ apt install -y \
   python3-testresources \
   python2 \
   lsb-release \
-  openjdk-11-jdk \
   openjdk-17-jdk \
   git \
   azure-cli \
@@ -149,14 +148,14 @@ apt install -y \
   gettext \
   libncurses-dev
 
-wget https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz -O - | tar xz
+wget https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_${ARCHITECTURE}.tar.gz -O - | tar xz
 mv flux /usr/local/bin/flux
 
-wget https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
+wget https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCHITECTURE}/kubectl -O /usr/local/bin/kubectl
 
-wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar xz
-mv linux-amd64/helm /usr/local/bin/helm
-rm -rf linux-amd64
+wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCHITECTURE}.tar.gz -O - | tar xz
+mv linux-${ARCHITECTURE}/helm /usr/local/bin/helm
+rm -rf linux-${ARCHITECTURE}
 chmod +x /usr/local/bin/kubectl
 
 pip3 install --upgrade docker-compose pip pip-check pyopenssl setuptools virtualenv
@@ -171,7 +170,7 @@ npm install --global \
   eslint \
   yarn
 
-update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+update-alternatives --set java /usr/lib/jvm/java-17-openjdk-${ARCHITECTURE}/bin/java
 
 #### RVM
 
@@ -186,11 +185,16 @@ rvm install ${RUBY_VERSION}
 
 ####
 
-curl https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o google-chrome-stable_current_amd64.deb
-apt install -y ./google-chrome-stable_current_amd64.deb
-rm -f google-chrome-stable_current_amd64.deb
+if [ ${ARCHITECTURE} = "amd64" ]; then
+  curl https://dl.google.com/linux/direct/google-chrome-stable_current_${ARCHITECTURE}.deb -o google-chrome-stable_current_${ARCHITECTURE}.deb
+  apt install -y ./google-chrome-stable_current_${ARCHITECTURE}.deb
+  rm -f google-chrome-stable_current_${ARCHITECTURE}.deb
+else
+  apt install -y chromium-browser
+fi
 
-curl -fL -o tfcmt.tar.gz https://github.com/suzuki-shunsuke/tfcmt/releases/download/v${TFCMT_VERSION}/tfcmt_linux_amd64.tar.gz
+
+curl -fL -o tfcmt.tar.gz https://github.com/suzuki-shunsuke/tfcmt/releases/download/v${TFCMT_VERSION}/tfcmt_linux_${ARCHITECTURE}.tar.gz
 tar -C /usr/bin -xzf ./tfcmt.tar.gz tfcmt
 
 [ -e /opt/google/chrome/libosmesa.so ] && rm /opt/google/chrome/libosmesa.so
@@ -211,13 +215,17 @@ if test -f "$FILE"; then
 fi
 
 #Download AzCopy
-wget https://aka.ms/downloadazcopy-v10-linux
+if [ ${ARCHITECTURE} = "amd64" ]; then
+  wget https://aka.ms/downloadazcopy-v10-linux
+else
+  wget -O downloadazcopy-v10-linux https://aka.ms/downloadazcopy-v10-linux-${ARCHITECTURE}
+fi
 
 #Expand Archive
 tar -xvf downloadazcopy-v10-linux
 
 #Move AzCopy to the destination you want to store it
-cp ./azcopy_linux_amd64_*/azcopy /usr/bin/
+cp ./azcopy_linux_${ARCHITECTURE}_*/azcopy /usr/bin/
 
 # see https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/
 wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
@@ -245,7 +253,7 @@ curl https://pyenv.run | bash
 ln -s /opt/.pyenv/bin/* /bin
 chown -R 1001:1001 /opt/.pyenv
 
-packages=( az azcopy docker docker-compose eslint gcc git google-chrome gulp java /usr/lib/jvm/java-17-openjdk-amd64/bin/java jq make node npm psql pyenv ruby rsync sonar-scanner terraform tfcmt tfenv virtualenv yarn wget zip )
+packages=( az azcopy docker docker-compose eslint gcc git google-chrome gulp java jq make node npm psql pyenv ruby rsync sonar-scanner terraform tfcmt tfenv virtualenv yarn wget zip )
 
 for i in "${packages[@]}"
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14034

### Change description ###
Create ARM64 based image
Updated pipeline to handle two separate images and definitions
Only amd64 based image will be published to GitHub to avoid accidental deployment of arm64 image until tested
arm64 images cannot use managed images which is a legacy technology anyway. Removing it in favour of publishing to image gallery on PR build and then deleting the published image
There is a feature request to exclude from latest which hasn't been actioned yet https://github.com/hashicorp/packer-plugin-azure/issues/34

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
