### PR TITLE
DTSPO-14034 - Keep image versions in sync

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            AZURE_IMAGE_VERSION=$(az sig image-version list --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg --query '[].{name:name}' -o tsv | sort -V | tail -n1)
+            AZURE_IMAGE_VERSION=$(az sig image-version list --gallery-image-definition jenkins-ubuntu --gallery-name hmcts --resource-group hmcts-image-gallery-rg --query '[].{name:name}' -o tsv | sort -V | tail -n1)
             IFS=. read -r major minor patch <<<"$AZURE_IMAGE_VERSION"
             ((patch++))
             printf -v AZURE_IMAGE_VERSION '%d.%d.%d' "$major" "$minor" "$((patch))"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14034

### Change description ###
Updating the versions so amd64 and arm64 are in sync to make renovate updates easier in the flux repos
Means we don't need config to determine which one is being updated
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
