### PR TITLE
DTSPO-15526 - Add yarn folder to both architectures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              azure_image_version=$(System.PullRequest.PullRequestId)
+              azure_image_version="$(System.PullRequest.PullRequestId).0.0"
               image_name=$(image_name)
               jenkins_ssh_key=$(JENKINS_SSH_KEY)
               image_sku=$(image_sku)
@@ -121,7 +121,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            az sig image-version delete --gallery-image-version $(System.PullRequest.PullRequestId) --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+            az sig image-version delete --gallery-image-version "$(System.PullRequest.PullRequestId).0.0" --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
 
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'Master Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              azure_image_version="$(System.PullRequest.PullRequestId).0.0"
+              azure_image_version="$(System.PullRequest.PullRequestNumber).0.0"
               image_name=$(image_name)
               jenkins_ssh_key=$(JENKINS_SSH_KEY)
               image_sku=$(image_sku)
@@ -121,7 +121,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            az sig image-version delete --gallery-image-version "$(System.PullRequest.PullRequestId).0.0" --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+            az sig image-version delete --gallery-image-version "$(System.PullRequest.PullRequestNumber).0.0" --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
 
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'Master Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       - task: AzureCLI@2.208.0
         displayName: Delete published image from previous failure
         condition: and(succeededOrFailed(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-        name: delete_pr_azure_image_version
+        name: delete_failed_pr_image
         inputs:
           azureSubscription: dts-management-prod-intsvc
           scriptType: bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,12 +139,13 @@ jobs:
           options: --only=azure-arm.master-build-and-publish
 
   - job: Publish_release
+    dependsOn: build_image
     pool:
       vmImage: 'ubuntu-latest'
     timeoutInMinutes: "120"
     steps:
       - checkout: self
-      
+
       - task: GitHubRelease@1
         displayName: Create GitHubRelease
         condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              azure_image_version="$(System.PullRequest.PullRequestNumber).0.0"
+              azure_image_version=$(System.PullRequest.PullRequestNumber).0.0
               image_name=$(image_name)
               jenkins_ssh_key=$(JENKINS_SSH_KEY)
               image_sku=$(image_sku)
@@ -121,7 +121,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            az sig image-version delete --gallery-image-version "$(System.PullRequest.PullRequestNumber).0.0" --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+            az sig image-version delete --gallery-image-version $(azure_image_version) --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
 
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'Master Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,17 @@ jobs:
             az group delete --name $group --yes
             done
 
+      - task: AzureCLI@2.208.0
+        displayName: Delete published PR build image version
+        condition: and(succeededOrFailed(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+        name: delete_pr_azure_image_version
+        inputs:
+          azureSubscription: dts-management-prod-intsvc
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            az sig image-version delete --gallery-image-version $(System.PullRequest.PullRequestNumber).0.0 --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+
       - task: riezebosch.Packer.PackerTool.PackerTool@0
         displayName: 'Install Packer'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,7 +121,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            az sig image-version delete --gallery-image-version $(azure_image_version) --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+            az sig image-version delete --gallery-image-version $(System.PullRequest.PullRequestNumber).0.0 --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
 
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'Master Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
         inputs:
           templatePath: $(templatePath)
           variables: |
-              azure_image_version=$(get_azure_image_version.azure_image_version)
+              azure_image_version=$(System.PullRequest.PullRequestId)
               image_name=$(image_name)
               jenkins_ssh_key=$(JENKINS_SSH_KEY)
               image_sku=$(image_sku)
@@ -121,7 +121,7 @@ jobs:
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
-            az sig image-version delete --gallery-image-version $(get_azure_image_version.azure_image_version) --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
+            az sig image-version delete --gallery-image-version $(System.PullRequest.PullRequestId) --gallery-image-definition $(image_name) --gallery-name hmcts --resource-group hmcts-image-gallery-rg
 
       - task: riezebosch.Packer.Packer.Packer@1
         displayName: 'Master Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,9 +138,16 @@ jobs:
           azureSubscription: dts-management-prod-intsvc
           options: --only=azure-arm.master-build-and-publish
 
+  - job: Publish_release
+    pool:
+      vmImage: 'ubuntu-latest'
+    timeoutInMinutes: "120"
+    steps:
+      - checkout: self
+      
       - task: GitHubRelease@1
         displayName: Create GitHubRelease
-        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.image_name, 'jenkins-ubuntu'))
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
         inputs:
           gitHubConnection: 'GitHub Management - Full Repo Access'
           repositoryName: '$(Build.Repository.Name)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
             done
 
       - task: AzureCLI@2.208.0
-        displayName: Delete published PR build image version
+        displayName: Delete published image from previous failure
         condition: and(succeededOrFailed(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
         name: delete_pr_azure_image_version
         inputs:

--- a/jenkins-agent-ubuntu.pkr.hcl
+++ b/jenkins-agent-ubuntu.pkr.hcl
@@ -115,6 +115,8 @@ source "azure-arm" "pr-build-and-publish" {
      image_version       = var.azure_image_version
      replication_regions = ["UK South"]
    }
+  
+  shared_gallery_image_version_exclude_from_latest = true
 }
 
 source "azure-arm" "master-build-and-publish" {

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -185,15 +185,8 @@ npm install --global \
 
 update-alternatives --set java /usr/lib/jvm/java-17-openjdk-${ARCHITECTURE}/bin/java
 
-#### DTSPO-15526 Testing .yarn folder move
-if [ ${ARCHITECTURE} = "arm64" ]; then
-  {
-    mkdir /opt/.yarn
-    chown -R 1001:1001 /opt/.yarn
-  } || {
-    echo "yarn config failure"
-  }
-fi
+mkdir /opt/.yarn
+chown -R 1001:1001 /opt/.yarn
 
 #### RVM
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15526

### Change description ###
Add `/opt/.yarn` to x64 arch as well as arm64
Also update version convention on PRs to use PR number as a base e.g. `173.0.0` to prevent master versions being accidentally deleted
Also fix github release being created when one image pipeline fails. GitHub release should be created only when both pass

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
