### PR TITLE
DTSPO-13145: Pipelines failing due to library mismatch

### DIFF
--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -171,7 +171,7 @@ mv linux-${ARCHITECTURE}/helm /usr/local/bin/helm
 rm -rf linux-${ARCHITECTURE}
 chmod +x /usr/local/bin/kubectl
 
-pip3 install --upgrade docker-compose pip pip-check pyopenssl setuptools virtualenv
+pip3 install --upgrade docker-compose pip pip-check pyopenssl setuptools virtualenv urllib3 requests
 
 USER=$(whoami)
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-13145


### Change description ###
Updating relevant libraries to resolve error as a couple of pipelines are failing on the same issue. After investigating, accepted solution is to update both urllib3 and requests libraries.

e.g. https://build.hmcts.net/job/HMCTS_a_to_c/job/ccd-data-store-api/job/master/504/execution/node/277/log/

