### PR TITLE
Revert "DTSPO-13145: Pipelines failing due to library mismatch"

### DIFF
--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -171,7 +171,7 @@ mv linux-${ARCHITECTURE}/helm /usr/local/bin/helm
 rm -rf linux-${ARCHITECTURE}
 chmod +x /usr/local/bin/kubectl
 
-pip3 install --upgrade docker-compose pip pip-check pyopenssl setuptools virtualenv urllib3 requests
+pip3 install --upgrade docker-compose pip pip-check pyopenssl setuptools virtualenv
 
 USER=$(whoami)
 


### PR DESCRIPTION
Reverts hmcts/jenkins-packer#190

Found that this was not the cause of this issue: https://tools.hmcts.net/jira/browse/DTSPO-17244
Testing via cnp-flux-config after reverting there