### PR TITLE
Add mssql-tools18 package for the Jenkins agent

### DIFF
--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -157,9 +157,10 @@ apt install -y \
   pdftk-java \
   libreoffice-core \
   libreoffice-writer \
-  ffmpeg \
-  msodbcsql17 \
-  mssql-tools \
+  ffmpeg
+  
+ACCEPT_EULA=Y apt install -y \
+  mssql-tools18 \
   unixodbc-dev
 
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -155,7 +155,7 @@ apt install -y \
   libreoffice-core \
   libreoffice-writer \
   ffmpeg \
-  mssql-tools \
+  mssql-tools18 \
   unixodbc-dev
 
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -155,7 +155,7 @@ apt install -y \
   libreoffice-core \
   libreoffice-writer \
   ffmpeg \
-  mssql-tools18 \
+  mssql-tools \
   unixodbc-dev
 
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -158,6 +158,7 @@ apt install -y \
   libreoffice-core \
   libreoffice-writer \
   ffmpeg \
+  msodbcsql17 \
   mssql-tools \
   unixodbc-dev
 

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -67,6 +67,9 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key a
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+curl "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list" | sudo tee /etc/apt/sources.list.d/mssql-release.list
+
 apt update
 apt install -y nodejs
 

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -158,7 +158,7 @@ apt install -y \
   libreoffice-core \
   libreoffice-writer \
   ffmpeg \
-  mssql-tools18 \
+  mssql-tools \
   unixodbc-dev
 
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc

--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -154,7 +154,9 @@ apt install -y \
   pdftk-java \
   libreoffice-core \
   libreoffice-writer \
-  ffmpeg
+  ffmpeg \
+  mssql-tools18 \
+  unixodbc-dev
 
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list


### PR DESCRIPTION
Needed to run sqlcmd commands via the Jenkins agent, to create and insert into tables on the mi-synapse dedicated SQL pool in a Jenkins build.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change
