### PR TITLE
Removing renovate and downgrading helm to unblock civil team

### DIFF
--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -5,8 +5,8 @@
 
 #renovate: datasource=github-tags depName=fluxcd/flux2
 export FLUX_VERSION=$(echo v2.6.3 | tr -d 'v')
-#renovate: datasource=github-tags depName=helm/helm
-export HELM_VERSION=$(echo v3.18.3 | tr -d 'v')
+
+export HELM_VERSION=$(echo v3.17.2 | tr -d 'v')
 #renovate: datasource=github-tags depName=kubernetes/kubectl
 export KUBECTL_VERSION=$(echo v1.26.0 | tr -d 'v')
 #renovate: datasource=node-version depName=node versioning=node


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-26519

### Change description
Removing reference to renovate to stop auto upgrades on helm. 

Also specifying version of helm to 3.17.2 to unblock civil team. 

### Testing done


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
