### PR TITLE
DTSPO-31433: Add Java 25 (temurin-25-jdk) to Jenkins agent image

### DIFF
--- a/provision-jenkins-ubuntu-agent.sh
+++ b/provision-jenkins-ubuntu-agent.sh
@@ -187,7 +187,9 @@ wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /et
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 
 apt update
-apt install -y temurin-21-jdk
+apt install -y \
+  temurin-21-jdk \
+  temurin-25-jdk
 
 wget https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_${ARCHITECTURE}.tar.gz -O - | tar xz
 mv flux /usr/local/bin/flux


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31433

### Change description

Install temurin-25-jdk alongside the existing temurin-21-jdk so new agents provisioned from this image have Java 25 available at /usr/lib/jvm/temurin-25-jdk-*, matching the path cnp-jenkins-library uses to resolve JAVA_HOME for Java 25 builds.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
